### PR TITLE
openbox-magic-pixel-workaround for bullseye

### DIFF
--- a/config/archives/x2go.list.chroot
+++ b/config/archives/x2go.list.chroot
@@ -1,1 +1,1 @@
-deb http://packages.x2go.org/debian buster main
+deb http://packages.x2go.org/debian bullseye main

--- a/config/package-lists/desktop.list.chroot
+++ b/config/package-lists/desktop.list.chroot
@@ -1,7 +1,6 @@
 libevdev2 
 libmtdev1 
 x11vnc 
-x11vnc-data 
 xserver-xorg-input-all
 xserver-xorg-input-wacom
 xserver-xorg-video-all


### PR DESCRIPTION
Hi!

At my university, I am setting up an X2Go-TCE powered lab for programming classes next semester. I had to build a live image based on the newly-released Debian Bullseye, because of support for GPU onboard recent Intel NUCs we are going to use as a thin clients.

And I've managed to, with the following limitations:
1. Build script from the wiki (https://wiki.x2go.org/doku.php/doc:howto:tce) does not work properly with an lb_config in Bullseye, so build process has to be run on Buster instead. Right now I don't have enough time to figure out how to properly use the new lb_config, so this was the simplest solution.
2. Because of a new naming schema for security updates repository (bullseye-security instead of bullseye/updates), I disabled such updates in x2go-tce-config. Again, I don't have enough time to properly resolve that problem.
3. nomagicpixel=1 option does not work anymore. We can live without it, as I configured similar feature on the server side, but it may be needed by someone else, so I pay attention to this.

Except for that, image built this way works fine, so I decided to share back my slightly modified branch - as a pull request for the Buster one, because I've based on it (and I has to pick one). Of course, I also needed to modify x2go-tce-build script to properly set LBX2GO_DEBVERSION.

For disabling magic pixel on the server side as I mentioned, one has to set X2GO_NXAGENT_DEFAULT_OPTIONS="-nomagicpixel" in /etc/x2go/x2goagent.options. It is worth a proper notice on the wiki doc:howto:tce page I think, which by the way is a bit messy.
Anyway, I find X2Go-TCE as a great project. To some extent it resembles Sun Rays that we also used back in time, but which unfortunately got screwed up by Oracle after acquiring Sun Microsystems. And it will be even closer to the technics behind SRs, when KDrive will mature and would be used in TCE environment.